### PR TITLE
Fix font size on extra large heading

### DIFF
--- a/themeunittestdata.wordpress.xml
+++ b/themeunittestdata.wordpress.xml
@@ -1102,8 +1102,8 @@
 <h2 class="has-large-font-size">Large H2 Heading</h2>
 <!-- /wp:heading -->
 
-<!-- wp:heading {"fontSize":"large"} -->
-<h2 class="has-large-font-size">Extra Large H2 Heading</h2>
+<!-- wp:heading {"fontSize":"x-large"} -->
+<h2 class="has-x-large-font-size">Extra Large H2 Heading</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"fontSize":"small"} -->


### PR DESCRIPTION
The Extra Large Heading in the **WP 6.1 Font size scale** post had the large size applied by mistake. This fixes that.

Closes #80.