### PR TITLE
64 block test file: Remove duplicate <![CDATA[ from the login block post

### DIFF
--- a/64-block-test-data.xml
+++ b/64-block-test-data.xml
@@ -11697,7 +11697,7 @@ Code is poetry</pre>
 <p>Note: test this block both when logged in and logged out.</p>
 <!-- /wp:paragraph -->
 
-<![CDATA[<!-- wp:loginout /-->
+<!-- wp:loginout /-->
 
 <!-- wp:paragraph -->
 <p>Without redirect to current URL:</p>


### PR DESCRIPTION
The post for the login block had a duplicate and miss placed `<![CDATA[` tag which broke the post content in Twenty Sixteen.

This PR removes the `<![CDATA[` and closes https://github.com/WordPress/theme-test-data/issues/86

### Testing instructions
Confirm that the post content in the Login/out post and imports without errors and displays correctly in the block editor and on the front of the website.